### PR TITLE
2 bits of opcode and 8 bits of address (10bit total)

### DIFF
--- a/93C46.cpp
+++ b/93C46.cpp
@@ -135,7 +135,8 @@ word eeprom_93C46::read(byte addr) {
 	
 	int amtBits;
 	if(_mode == EEPROM_93C46_MODE_16BIT) {
-		send_bits(READ | (addr & 0x3F), 8);
+		send_bits(READ >> 6, 2);
+		send_bits(addr, 8);
 		amtBits = 16;
 	} else {
 		send_bits(READ<<1 | (addr & 0x7F), 9);


### PR DESCRIPTION
this is related to https://github.com/0xJoey/Arduino_93C46/issues/4

I used this library almost one year ago to read tachometer eeprom, this is what I changed to fix the issue. I don't remember now what to look for regarding "other functions".